### PR TITLE
fix(src): remove .ts extension from imports

### DIFF
--- a/src/args.ts
+++ b/src/args.ts
@@ -1,4 +1,4 @@
-import { split } from './shellwords.ts'
+import { split } from './shellwords'
 
 /**
  * Type for parsed command line arguments.

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,2 +1,2 @@
-export { parse } from './parser.ts'
-export { parseArgs } from './args.ts'
+export { parse } from './parser'
+export { parseArgs } from './args'

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest'
-import { parse } from './parser.ts'
+import { parse } from './parser'
 
 const testCases = [
   {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,4 +1,4 @@
-import { parseArgs } from './args.ts'
+import { parseArgs } from './args'
 
 type ParsedCommand<T = unknown> = {
   method: string


### PR DESCRIPTION
## Summary
- Remove `.ts` file extensions from all imports in `src/` folder
- Affects `mod.ts`, `parser.ts`, `parser.test.ts`, and `args.ts`

## Test plan
- [ ] Verify tests still pass with `deno test`
- [ ] Verify build works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)